### PR TITLE
v1.0.2

### DIFF
--- a/.jenkins/deploy
+++ b/.jenkins/deploy
@@ -53,7 +53,6 @@ pipeline {
           // Using a pre-authorized key, connect to the specified server and run the deploy script.
           sshagent(credentials : ['a687b920-fcb4-41e4-a878-5ae1f6850b26']) {
             println "> deploying ${IMAGE} ($NAME) to ${DEPLOY_TARGET}..."
-            // sh "$ssh 'echo $targetsData | base64 -d > $targetsFile"
             sh "$ssh 'echo $script | base64 -d > ${filename} && \
               chmod +x ${filename} && \
               NAME=$NAME \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edge/monitor",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@edge/monitor",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@edge/log": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge/monitor",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Performance monitoring tool for the Edge network",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",

--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,10 @@
               <button type="submit">Save</button>
               <button type="button" @click.prevent="append">Append</button>
               <button type="button" @click.prevent="refreshStatus">Refresh status</button>
+              <button type="button" @click.prevent="toggleAutoRefresh">
+                <span v-if="autoRefresh">Auto-refresh <strong>on</strong></span>
+                <span v-else>Auto-refresh <strong>off</strong></span>
+              </button>
             </div>
             <table>
               <thead>

--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -89,7 +89,10 @@ const app = Vue.createApp({
     return {
       config: {},
       status: {},
-      targets: []
+      targets: [],
+
+      autoRefresh: false,
+      iAutoRefresh: null
     }
   },
   components: {
@@ -225,13 +228,23 @@ const app = Vue.createApp({
     },
     setURL(i, e) {
       this.targets[i].url = e.target.value
+    },
+    toggleAutoRefresh() {
+      if (this.autoRefresh) {
+        this.autoRefresh = false
+        // eslint-disable-next-line no-undef
+        clearInterval(this.iAutoRefresh)
+      }
+      else {
+        this.autoRefresh = true
+        this.iAutoRefresh = setInterval(() => this.redraw(), 1000)
+      }
     }
   },
   async mounted() {
     await this.refreshConfig()
     await this.refresh()
     await this.refreshStatus()
-    // setInterval(() => this.redraw(), 1000)
   }
 })
 


### PR DESCRIPTION
This patch adds an auto-refresh toggle to make it easier to watch monitor status.

**Be mindful that auto refresh should be disabled while editing monitor targets - refreshing the page causes the target configuration to reset.**

Closes #6 